### PR TITLE
Generate and upload AppImage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,6 @@ script:
   
 after_success:
   - find syzygy.AppDir/ -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
-  - # curl --upload-file syzygy*.AppImage https://transfer.sh/syzygy-git.$(git rev-parse --short HEAD)-x86_64.AppImage
+  - # curl --upload-file System_Syzygy*.AppImage https://transfer.sh/System_Syzygy-git.$(git rev-parse --short HEAD)-x86_64.AppImage
   - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
-  - bash upload.sh syzygy*.AppImage*
+  - bash upload.sh System_Syzygy*.AppImage*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+language: cpp
+compiler: gcc
+sudo: require
+dist: trusty
+
+install:
+  - sudo apt-get update
+  - sudo apt-get install libegl1-mesa-dev libgles2-mesa-dev # https://github.com/travis-ci/travis-ci/issues/9065
+  - sudo apt-get -y install libsdl2-dev python curl curl libssl-dev cargo rustc
+  - cargo build --release
+
+script:
+  - mkdir -p  syzygy.AppDir/usr/bin # "make install" is missing, hence doing it by hand
+  - mkdir -p  syzygy.AppDir/usr/lib/syzygy
+  - mkdir -p syzygy.AppDir/usr/share/applications/
+  - mkdir -p syzygy.AppDir/usr/share/icons/hicolor/scalable/apps/
+  - touch syzygy.AppDir/usr/share/icons/hicolor/scalable/apps/syzygy.svg # FIXME
+  - cp data/linux/syzygy.desktop syzygy.AppDir/usr/share/applications/
+  - cp ./target/release/syzygy syzygy.AppDir/usr/bin/
+  - cp -r ./data syzygy.AppDir/usr/lib/syzygy/
+  - sed -i -e 's|/usr|././|g' ./syzygy.AppDir/usr/bin/syzygy # FIXME; https://github.com/mdsteele/syzygy/issues/3#issuecomment-440459518
+  - wget -c -nv "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+  - chmod a+x linuxdeployqt-continuous-x86_64.AppImage
+  - ./linuxdeployqt-continuous-x86_64.AppImage --appimage-extract # FIXME; https://github.com/mdsteele/syzygy/issues/3#issuecomment-440459518
+  - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+  - export VERSION=$(git rev-parse --short HEAD) # linuxdeployqt uses this for naming the file
+  - ./linuxdeployqt-continuous-x86_64.AppImage syzygy.AppDir/usr/share/applications/*.desktop -bundle-non-qt-libs # FIXME; https://github.com/mdsteele/syzygy/issues/3#issuecomment-440459518
+  - rm -f ./syzygy.AppDir/AppRun && wget -c "https://github.com/AppImage/AppImageKit/releases/download/continuous/AppRun-x86_64" -O ./syzygy.AppDir/AppRun && chmod +x ./syzygy.AppDir/AppRun
+  - PATH=./squashfs-root/usr/bin:$PATH ./squashfs-root/usr/bin/appimagetool --no-appstream ./syzygy.AppDir -g # FIXME; https://github.com/mdsteele/syzygy/issues/3#issuecomment-440459518
+  
+after_success:
+  - find syzygy.AppDir/ -executable -type f -exec ldd {} \; | grep " => /usr" | cut -d " " -f 2-3 | sort | uniq
+  - # curl --upload-file syzygy*.AppImage https://transfer.sh/syzygy-git.$(git rev-parse --short HEAD)-x86_64.AppImage
+  - wget -c https://github.com/probonopd/uploadtool/raw/master/upload.sh
+  - bash upload.sh syzygy*.AppImage*

--- a/data/linux/syzygy.desktop
+++ b/data/linux/syzygy.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=syzygy
+Comment=A narrative meta-puzzle game
+Exec=syzygy
+Icon=syzygy
+Terminal=false
+Type=Application
+Categories=Game;

--- a/data/linux/syzygy.desktop
+++ b/data/linux/syzygy.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Name=syzygy
+Name=System Syzygy
 Comment=A narrative meta-puzzle game
 Exec=syzygy
 Icon=syzygy


### PR DESCRIPTION
Currently it is more cumbersome for Linux users than for Mac or Windows users to download and run the game.

![download](https://user-images.githubusercontent.com/2480569/48985385-c9097600-f0fe-11e8-9cb8-6724affe86ab.png)

This PR, when merged, will compile this application on [Travis CI](https://travis-ci.org/) upon each `git push`, and upload an [AppImage](http://appimage.org/) to your GitHub Releases page.

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Applications packaged as an AppImage can run on many distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Works out of the box, no installation of runtimes needed
- Optional desktop integration with `appimaged`
- Optional binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can optionally GPG2-sign your AppImages (inside the file)
- Works on Live ISOs
- Can use the same AppImages when dual-booting multiple distributions
- Can be listed in the [AppImageHub](https://appimage.github.io/apps) central directory of available AppImages
- Can double as a self-extracting compressed archive with the `--appimage-extract` parameter
- No repositories needed. Suitable/optimized for air-gapped (offline) machines

[Here is an overview](https://appimage.github.io/apps) of projects that are already distributing upstream-provided, official AppImages.

__PLEASE NOTE:__ For this to work, you need to enable Travis CI for your repository as [described here](https://travis-ci.org/getting_started) __prior to merging this__, if you haven't already done so. Also, You need to set up `GITHUB_TOKEN` in Travis CI for this to work; please see https://github.com/probonopd/uploadtool.
If you would like to see only one entry for the Pull Request in your project's history, then please enable [this GitHub functionality](https://help.github.com/articles/configuring-commit-squashing-for-pull-requests/) on your repo. It allows you to squash (combine) the commits when merging.

If you have questions, AppImage developers are on #AppImage on irc.freenode.net.