### PR TITLE
Correct new warnings and lints flagged by Rust 1.47

### DIFF
--- a/src/gui/sound.rs
+++ b/src/gui/sound.rs
@@ -332,7 +332,7 @@ impl AudioCallback for SoundMixer {
             new_sounds.push(sound);
         }
         debug_assert!(self.active_sounds.is_empty());
-        mem::replace(&mut self.active_sounds, new_sounds);
+        self.active_sounds = new_sounds;
     }
 }
 

--- a/src/save/puzzles/attic.rs
+++ b/src/save/puzzles/attic.rs
@@ -51,9 +51,9 @@ impl AtticState {
         match pos {
             (1, 0) => self.is_toggled((1, 1)) ^ self.is_toggled((2, 1)),
             (2, 0) => {
-                (self.is_toggled((1, 1))
+                self.is_toggled((1, 1))
                     ^ self.is_toggled((2, 1))
-                    ^ self.is_toggled((3, 1)))
+                    ^ self.is_toggled((3, 1))
             }
             (3, 0) => true,
             (4, 0) => self.is_toggled((3, 1)) ^ self.is_toggled((4, 1)),

--- a/src/save/puzzles/noreturn.rs
+++ b/src/save/puzzles/noreturn.rs
@@ -163,7 +163,7 @@ impl Tomlable for NoReturnState {
                 let value = cmp::min(value, order.len() - 1);
                 order[index] = value;
             }
-            for (index, value) in order.clone().into_iter().enumerate() {
+            for (index, value) in order.clone().iter().enumerate() {
                 if order[..index].contains(value) {
                     order = INITIAL_ORDER;
                     break;

--- a/src/save/puzzles/order.rs
+++ b/src/save/puzzles/order.rs
@@ -158,7 +158,7 @@ impl Tomlable for OrderState {
             let value = cmp::min(cmp::max(0, value) as usize, order.len() - 1);
             order[index] = value;
         }
-        for (index, value) in order.clone().into_iter().enumerate() {
+        for (index, value) in order.clone().iter().enumerate() {
             if order[..index].contains(value) {
                 order = *INITIAL_ORDER;
                 break;


### PR DESCRIPTION
The Rust linter has gotten more finicky as time goes on. It's found three issues in the current codebase:

* A case of redundant parentheses.
* A case where an important return value is ignored. Fortunately, it turns out that ignoring the return value means that the function can be replaced with a simple assignment.
* Two cases of `into_iter` being called on array types. Arrays do not actually implement `IntoIterator` so this ends up doing extra borrowing under the hood to make things compile. However, this will result in semantics changes if arrays ever get the trait implemented, so the compiler now warns that this will become a hard error in a future release. The fix (preserving current behavior) is to replace `into_iter` calls with simple `iter` calls.